### PR TITLE
Add marking test cases

### DIFF
--- a/pytest_case/case.py
+++ b/pytest_case/case.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from collections import defaultdict
 from functools import reduce
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Union, overload
 
 import pytest
+from _pytest.mark import ParameterSet
 
 from pytest_case.consts import PYTEST_MARKER
 from pytest_case.types import UnwrappedFunc
@@ -23,9 +23,8 @@ def case(name: str, *args: Any, **kwargs: Any) -> Callable[..., Any]: ...
 
 
 def wrap_func(
-    ids: Sequence[str],     # TODO: Support dynamic func IDs
     argnames: Sequence[str],
-    argvalues: Iterable[Sequence[object]],
+    parameter_sets: Iterable[ParameterSet],
     defaults: Dict[str, Any],
 ) -> Callable[..., Callable[..., Any]]:
     def wrapper(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -33,10 +32,9 @@ def wrap_func(
         We wrap the function with `pytest.mark.parametrize` with every case so it will exist in the last case.
         We unwrap the mark for every wrapped case.
         """
-        return  pytest.mark.parametrize(
-            ids=ids,
+        return pytest.mark.parametrize(
             argnames=argnames,
-            argvalues=argvalues,
+            argvalues=parameter_sets,
         )(pytest.mark.case(defaults=defaults)(func))
     return wrapper
 
@@ -82,7 +80,7 @@ def _generator_case(gen: Iterable[Any], func: Callable[..., Any], **kwargs: Any)
     )
 
 def case(name_or_gen: Union[str, Iterable[Any]], *args: Any, **kwargs: Any) -> Callable[..., Any]:
-    marks = kwargs.pop("marks", None) # noqa: F841
+    marks = kwargs.pop("marks", None) or tuple()
 
     def decorator(func: Callable[[Any], Any]) -> Callable[[Any], Any]:
         # Can't check for `Iterable` because `str` is also iterable
@@ -101,15 +99,17 @@ def case(name_or_gen: Union[str, Iterable[Any]], *args: Any, **kwargs: Any) -> C
                 f"Test '{func.__name__}' expected {len(func_params)} but case got {len(args) + len(kwargs)} params"
             )
 
-        ids = []
         argnames = []
         defaults: Dict[str, Any] = {}
-        args_dict = defaultdict(tuple)
+        case_parameter_sets: Iterable[ParameterSet] = []
 
         if is_case(func):
             # Wrapping another case
-            func, _, ids, argnames, argvalues, defaults = unwrap_func(func)
-            args_dict = dict(zip(argnames, list(zip(*argvalues))))
+            unwrapped_func_attrs = unwrap_func(func)
+            func = unwrapped_func_attrs.unwrapped_func
+            argnames = unwrapped_func_attrs.argnames
+            case_parameter_sets = unwrapped_func_attrs.argvalues
+            defaults = unwrapped_func_attrs.defaults
         else:
             # If the wrapped function is a test function...
             func_params = get_func_param_names(func)
@@ -118,13 +118,12 @@ def case(name_or_gen: Union[str, Iterable[Any]], *args: Any, **kwargs: Any) -> C
             # All the rest should be fixtures or will raise an error because tey are not provided
             argnames = (*func_required_params, *defaults.keys())
 
-        if "marks" in argnames:
-            raise TypeError("Function parameters cannot contain reserved keyword 'marks'")
-
-        ids = [name] + ids
-
+            if "marks" in argnames:
+                raise TypeError("Function parameters cannot contain reserved keyword 'marks'")
+        
         func.__defaults__ = None
 
+        case_argvalues = []
         for arg_index, argname in enumerate(argnames):
             new_argvalue = None
 
@@ -140,16 +139,13 @@ def case(name_or_gen: Union[str, Iterable[Any]], *args: Any, **kwargs: Any) -> C
                 # Provided in kwargs - use it
                 new_argvalue = kwargs[argname]
 
-            if new_argvalue is None:
-                # Should never happen.
-                raise TypeError("Something weird has happened...")
+            case_argvalues.append(new_argvalue)
 
-            args_dict[argname] = (new_argvalue, ) + args_dict[argname]
+        case_parameter_sets = [pytest.param(*case_argvalues, marks=marks, id=name)] + case_parameter_sets
 
         return wrap_func(
-            ids=ids,
-            argnames=list(args_dict.keys()),
-            argvalues=list(zip(*args_dict.values())),
+            argnames=argnames,
+            parameter_sets=case_parameter_sets,
             defaults=defaults,
         )(func)
     

--- a/pytest_case/types.py
+++ b/pytest_case/types.py
@@ -1,18 +1,17 @@
 
-from dataclasses import astuple, dataclass
-from typing import Any, Callable, Dict, List, Tuple
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Tuple
 
 import pytest
+from _pytest.mark import ParameterSet
 
 
 @dataclass
 class UnwrappedFunc:
     unwrapped_func: Callable[[Any], Any]
     func_markers: List[pytest.MarkDecorator]
-    ids: List[str]
-    argnames: Tuple[str]
-    argvalues: List[Tuple[Any]]
-    defaults: Dict[str, Any]
 
-    def __iter__(self):
-        return iter(astuple(self))
+    argnames: Tuple[str]
+    argvalues: Iterable[ParameterSet]
+
+    defaults: Dict[str, Any]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -77,3 +77,9 @@ def test__case__generator(a, b) -> None:
 @case(product(("a", "b"), ("1", "2")), name="({}, {})")
 def test__case__product(a, b) -> None:
     assert a in ("a", "b") and b in ("1", "2")
+
+@case("should pass", 1)
+@case("should skip", 2, marks=pytest.mark.skip)
+@case("should fail", -1, marks=pytest.mark.xfail(reason="This number is negative"))
+def test__case__marking(a: int) -> None:
+    assert a > 0


### PR DESCRIPTION
This PR changes how we pass the arguments from each case to the next.
Previously, we passed IDs, argnames, argvalues, by hand each time. 
Now we use the ParameterSet from pytest to pass the argvalues and marks.